### PR TITLE
feat: read token from a file

### DIFF
--- a/HomeAssistantSettings.qml
+++ b/HomeAssistantSettings.qml
@@ -14,6 +14,14 @@ PluginSettings {
         placeholder: "http://homeassistant.local:8123"
     }
 
+    StringSetting {
+        settingKey: "hassTokenPath"
+        label: "Long-Lived Acess Token Path"
+        description: "Path to a file containing the Long-Lived Access Token (e.g., /run/secrets/hass_token). Take precedence over the field below. Only absolute path is supported."
+        defaultValue: ""
+        placeholder: "/run/secrets/hass_token"
+    }
+
     // Custom password field for token
     Column {
         id: tokenSetting

--- a/services/HomeAssistantService.qml
+++ b/services/HomeAssistantService.qml
@@ -3,6 +3,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import Quickshell
+import Quickshell.Io
 import qs.Common
 import qs.Services
 import "../components" as Components
@@ -14,7 +15,10 @@ Singleton {
 
     property bool haAvailable: false
     property string hassUrl: ""
-    property string hassToken: ""
+    property string hassTokenPath: ""
+    property string _tokenFromFile: ""
+    property string _tokenFromSettings: ""
+    property string hassToken: hassTokenPath !== "" ? _tokenFromFile : _tokenFromSettings
     property string entityIds: ""
     property int refreshInterval: 3
     property bool showAttributes: false
@@ -108,6 +112,18 @@ Singleton {
 
     property bool missingDependency: false
     property var socket: wsLoader.item
+
+    FileView {
+        id: tokenFileView
+        path: root.hassTokenPath
+        onTextChanged: {
+            root._tokenFromFile = tokenFileView.text().trim();
+            if (root.hassTokenPath !== "" && root._tokenFromFile === "") {
+                console.warn("HomeAssistantMonitor: Token file is empty or could not be read:", root.hassTokenPath);
+                root.hassTokenPath = "";
+            }
+        }
+    }
 
     Timer {
         id: callbackGcTimer
@@ -249,8 +265,8 @@ Singleton {
         }
 
         hassUrl = load("hassUrl", "http://homeassistant.local:8123");
-        var token = load("hassToken", "");
-        hassToken = token ? token.trim() : "";
+        _tokenFromSettings = load("hassToken", "").toString().trim();
+        hassTokenPath = load("hassTokenPath", "").toString().trim();
         
         entityIds = load("entityIds", "");
         refreshInterval = load("refreshInterval", 3);


### PR DESCRIPTION
Allow reading Long-lived Access Token from a file. 

Convenient for `agenix` or `sopnix`, or anything that would decrypt and mount the secret token at some location.

Changes:
- Use `FileView` from `Quickshell.Io` to read from the specified path.
- Use the content of that file as the token.
- Fallback to normal configured token if no path is specified, or the file couldn't be read or empty.