### PR TITLE
feat: per-entity conditional bar visibility

### DIFF
--- a/HomeAssistantWidget.qml
+++ b/HomeAssistantWidget.qml
@@ -14,6 +14,7 @@ PluginComponent {
     property bool showAttributes: pluginData.showAttributes !== undefined ? pluginData.showAttributes : true
     property var pinnedEntities: []
     property var customIcons: ({})
+    property var visibilityRules: ({})   // { entityId: { op, value } } — conditional bar visibility
 
     // Cache for status bar - use computed properties to ensure proper scope
     readonly property var cachedGlobalEntities: globalEntities.value || []
@@ -203,6 +204,7 @@ PluginComponent {
     Component.onCompleted: {
         syncPinnedEntitiesFromStorage();
         customIcons = loadPersistentUiValue("customIcons", ({}));
+        visibilityRules = loadPersistentUiValue("entityVisibility", ({}));
         syncSelectionState();
     }
 
@@ -500,6 +502,18 @@ PluginComponent {
         savePersistentUiValue("customIcons", icons);
     }
 
+    // rule = { op: "always"|"active"|"eq"|"ne"|"gt"|"lt", value } — pass null/"always" to clear.
+    function setEntityVisibility(entityId, rule) {
+        var rules = Object.assign({}, visibilityRules);
+        if (rule && rule.op && rule.op !== "always") {
+            rules[entityId] = rule;
+        } else {
+            delete rules[entityId];
+        }
+        visibilityRules = rules;
+        savePersistentUiValue("entityVisibility", rules);
+    }
+
     function openIconPicker(entityId) {
         iconPickerEntityId = entityId;
         iconSearchText = "";
@@ -519,6 +533,7 @@ PluginComponent {
         globalEntities: root.cachedGlobalEntities
         pinnedEntityIds: root.cachedPinnedEntities
         customIcons: root.customIcons
+        visibilityRules: root.visibilityRules
         barThickness: root.barThickness
         showHomeIcon: pluginData.showHomeIcon !== undefined ? pluginData.showHomeIcon : true
         showButtonsOnStatusBar: pluginData.showButtonsOnStatusBar !== undefined ? pluginData.showButtonsOnStatusBar : true
@@ -533,6 +548,7 @@ PluginComponent {
         globalEntities: root.cachedGlobalEntities
         pinnedEntityIds: root.cachedPinnedEntities
         customIcons: root.customIcons
+        visibilityRules: root.visibilityRules
         barThickness: root.barThickness
         showHomeIcon: pluginData.showHomeIcon !== undefined ? pluginData.showHomeIcon : true
         showButtonsOnStatusBar: pluginData.showButtonsOnStatusBar !== undefined ? pluginData.showButtonsOnStatusBar : true
@@ -679,6 +695,7 @@ PluginComponent {
                         showEntityDetails: root.showEntityDetails
                         showAttributes: root.showAttributes
                         customIcons: root.customIcons
+                        visibilityRules: root.visibilityRules
 
                         onRequestListView: listView => root.entityListView = listView
                         onRequestToggleExpand: entityId => root.toggleEntity(entityId)
@@ -686,6 +703,7 @@ PluginComponent {
                         onRequestToggleDetails: entityId => root.toggleEntityDetails(entityId)
                         onRequestRemoveEntity: entityId => HomeAssistantService.removeEntityFromMonitor(entityId)
                         onRequestOpenIconPicker: entityId => root.openIconPicker(entityId)
+                        onRequestSetVisibility: (entityId, rule) => root.setEntityVisibility(entityId, rule)
                     }
                 }
             }

--- a/components/EntityCard.qml
+++ b/components/EntityCard.qml
@@ -48,6 +48,7 @@ StyledRect {
     property bool isEditing: false
     property bool isRenaming: false
     property string _renameBaseline: ""
+    property var visibilityRule: null   // { op, value } or null (= always shown on bar)
 
     onIsEditingChanged: if (!isEditing) isRenaming = false
 
@@ -56,6 +57,7 @@ StyledRect {
     signal toggleDetails()
     signal removeEntity()
     signal openIconPicker()
+    signal setVisibility(var rule)   // null clears (always visible)
 
     function _getEffectiveState() {
         return EntityHelper.getEffectiveState(entityData);
@@ -452,6 +454,20 @@ StyledRect {
             backgroundOpacity: isPinned ? 0.3 : 0.7
             iconRotation: isPinned ? 0 : 45
             onClicked: entityCard.togglePin()
+        }
+
+        EditActionButton {
+            width: 32
+            height: 32
+            readonly property bool showWhenActive: !!(entityCard.visibilityRule && entityCard.visibilityRule.op === "active")
+            // Toggle: always shown  <->  only shown on the bar when the entity is "active"
+            // (state is not off/idle/none/closed/empty). Full op set lives in EntityHelper.entityVisible.
+            iconName: showWhenActive ? "filter_alt" : "visibility"
+            iconSize: 16
+            iconColor: showWhenActive ? (Theme.primary || "transparent") : Theme.surfaceText
+            backgroundColor: showWhenActive ? (Theme.primary || "transparent") : (Theme.surfaceContainerHigh || "transparent")
+            backgroundOpacity: showWhenActive ? 0.3 : 0.7
+            onClicked: entityCard.setVisibility(showWhenActive ? null : { "op": "active" })
         }
 
         EditActionButton {

--- a/components/EntityHelper.qml
+++ b/components/EntityHelper.qml
@@ -130,4 +130,44 @@ QtObject {
             theme
         );
     }
+
+    /**
+     * Decide whether a pinned entity should be shown on the bar, per a visibility rule.
+     * rule = { op: "always"|"active"|"eq"|"ne"|"gt"|"lt", value: <string|number> }
+     * A missing or "always" rule => always visible (backwards compatible).
+     * "active" = the state is "meaningful" — not in a set of empty/off-like values
+     * (off, idle, none, closed, standby, unavailable, unknown, 0, ""). This suits bar
+     * display (e.g. a countdown "12m" shows, "off" hides) and also covers on/open/playing.
+     * "gt"/"lt" compare the leading number of the state (e.g. "12m" -> 12);
+     * a non-numeric state => hidden.
+     * @param entityData - The entity data object
+     * @param rule - The visibility rule for this entity (may be undefined)
+     * @returns true if the entity should be shown
+     */
+    readonly property var _inactiveStates: ["", "0", "off", "idle", "none", "closed",
+        "standby", "unavailable", "unknown", "false", "not_home", "disconnected", "paused"]
+
+    function entityVisible(entityData, rule) {
+        if (!entityData) return false;
+        if (!rule || !rule.op || rule.op === "always") return true;
+
+        const state = getEffectiveState(entityData);
+        switch (rule.op) {
+        case "active":
+            return _inactiveStates.indexOf(String(state).trim().toLowerCase()) === -1;
+        case "eq":
+            return String(state) === String(rule.value);
+        case "ne":
+            return String(state) !== String(rule.value);
+        case "gt":
+        case "lt": {
+            const n = parseFloat(state);
+            const v = parseFloat(rule.value);
+            if (isNaN(n) || isNaN(v)) return false;
+            return rule.op === "gt" ? (n > v) : (n < v);
+        }
+        default:
+            return true;
+        }
+    }
 }

--- a/components/HomeAssistantEntityListPane.qml
+++ b/components/HomeAssistantEntityListPane.qml
@@ -20,6 +20,7 @@ Column {
     property var showEntityDetails: ({})
     property bool showAttributes: true
     property var customIcons: ({})
+    property var visibilityRules: ({})
 
     signal requestListView(ListView listView)
     signal requestToggleExpand(string entityId)
@@ -27,6 +28,7 @@ Column {
     signal requestToggleDetails(string entityId)
     signal requestRemoveEntity(string entityId)
     signal requestOpenIconPicker(string entityId)
+    signal requestSetVisibility(string entityId, var rule)
 
     width: parent ? parent.width : implicitWidth
     height: parent ? parent.height : implicitHeight
@@ -112,6 +114,7 @@ Column {
                 detailsExpanded: rowEntityData ? (root.showEntityDetails[rowEntityData.entityId] || false) : false
                 showAttributes: root.showAttributes
                 customIcons: root.customIcons
+                visibilityRule: rowEntityData ? (root.visibilityRules[rowEntityData.entityId] || null) : null
                 isEditing: root.isEditing
 
                 onToggleExpand: if (rowEntityData) root.requestToggleExpand(rowEntityData.entityId)
@@ -119,6 +122,7 @@ Column {
                 onToggleDetails: if (rowEntityData) root.requestToggleDetails(rowEntityData.entityId)
                 onRemoveEntity: if (rowEntityData) root.requestRemoveEntity(rowEntityData.entityId)
                 onOpenIconPicker: if (rowEntityData) root.requestOpenIconPicker(rowEntityData.entityId)
+                onSetVisibility: rule => { if (rowEntityData) root.requestSetVisibility(rowEntityData.entityId, rule) }
             }
         }
 

--- a/components/StatusBarContent.qml
+++ b/components/StatusBarContent.qml
@@ -16,11 +16,13 @@ Item {
     property var globalEntities: []  // All monitored entities (already includes optimistic states)
     property var pinnedEntityIds: []  // List of pinned entity IDs
     property var customIcons: ({})
+    property var visibilityRules: ({})  // { entityId: { op, value } } — conditional bar visibility
     property real barThickness: 0
     property bool showHomeIcon: true
     property bool showButtonsOnStatusBar: true
 
     property string _lastPinnedIdsStr: ""
+    property int visibleCount: 0        // pinned entities currently passing their visibility rule
 
     // ListModel for efficient incremental updates
     ListModel {
@@ -30,6 +32,19 @@ Item {
     // Sync model when data changes
     onGlobalEntitiesChanged: syncModel()
     onPinnedEntityIdsChanged: syncModel()
+    onVisibilityRulesChanged: recomputeVisibleCount()
+
+    // Count pinned entities that currently pass their visibility rule. Called on every
+    // model mutation so the "nothing to show" fallback stays correct.
+    function recomputeVisibleCount() {
+        const rules = visibilityRules || {};
+        var c = 0;
+        for (var i = 0; i < pinnedEntitiesModel.count; i++) {
+            const m = pinnedEntitiesModel.get(i);
+            if (EntityHelper.entityVisible(m, rules[m.entityId])) c++;
+        }
+        visibleCount = c;
+    }
 
     // Listen for entity data changes from HomeAssistantService (unified signal)
     Connections {
@@ -63,6 +78,7 @@ Item {
         const normalized = normalizeEntity(entityData);
         if (normalized) {
             pinnedEntitiesModel.set(index, normalized);
+            recomputeVisibleCount();
         }
     }
 
@@ -74,6 +90,7 @@ Item {
                 pinnedEntitiesModel.append(normalized);
             }
         }
+        recomputeVisibleCount();
     }
 
     function syncModel() {
@@ -131,7 +148,7 @@ Item {
             entityCount: root.entityCount
             showHomeIcon: root.showHomeIcon
             anchors.verticalCenter: parent.verticalCenter
-            visible: !root.haAvailable || pinnedEntitiesModel.count === 0
+            visible: !root.haAvailable || root.visibleCount === 0
         }
 
         Repeater {
@@ -161,7 +178,7 @@ Item {
             entityCount: root.entityCount
             showHomeIcon: root.showHomeIcon
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: pinnedEntitiesModel.count === 0
+            visible: root.visibleCount === 0
         }
 
         Repeater {
@@ -184,6 +201,8 @@ Item {
         Item {
             implicitWidth: root.orientation === Qt.Vertical ? root.barThickness : entityRowContent.implicitWidth
             implicitHeight: root.orientation === Qt.Vertical ? entityColumnContent.implicitHeight : root.barThickness
+            // Conditional visibility (Row/Column positioners collapse invisible children).
+            visible: EntityHelper.entityVisible(model, (root.visibilityRules || {})[model.entityId])
             readonly property bool availabilityIssue: model.state === "unavailable" || model.state === "unknown"
             readonly property color stateColor: availabilityIssue ? Theme.warning : HassConstants.getStateColor(model.domain || "", model.state || "", Theme)
 


### PR DESCRIPTION
Part of the roadmap in [#15](https://github.com/xxyangyoulin/dms-plugin-hass/issues/15).

**What:** lets a pinned entity be shown on the bar only when a per-entity rule passes, instead of always. Opt-in and backwards-compatible — a newly pinned entity defaults to `always` (current behavior).

**Motivation:** some entities are only worth showing sometimes — a countdown/timer while it runs, a door only when open, a battery only when low.

**How:**
- `EntityHelper.entityVisible(entityData, rule)` — pure evaluator: `always | active | eq | ne | gt | lt`. `active` = state isn't in a small off-like set (off/idle/none/closed/empty…), which suits text sensors as well as on/open/playing. `gt`/`lt` parse the leading number of the state (`"12m"` → 12).
- `StatusBarContent` gates each pinned delegate's visibility and tracks a `visibleCount` so the "nothing to show" home-icon fallback stays correct when everything's hidden.
- Rules persist under `entityVisibility` (same mechanism as `customIcons`); wired Widget → list pane → `EntityCard`.
- **UI (v1):** an "Always ↔ When active" toggle in the entity edit toolbar. The evaluator already supports the full op set; a richer condition editor is roadmap phase 2 — happy to shape that UX with your input before building it.

**Testing:** qmllint clean. Verified an override-remaining sensor shows only while active and hides otherwise; the home-icon fallback still appears when all pinned entities are hidden.